### PR TITLE
feat: adding configuration and transport structs

### DIFF
--- a/lib/src/configuration.rs
+++ b/lib/src/configuration.rs
@@ -40,8 +40,8 @@ impl Configuration {
     }
 
     pub fn set_base_path(&mut self, base_path: &str) -> &mut Self {
-        if base_path.is_empty() || !base_path.starts_with('/') {
-            panic!("Invalid base path");
+        if base_path.is_empty() {
+            panic!("Empty base path");
         }
         self.base_path = base_path.to_string();
         self

--- a/lib/src/configuration.rs
+++ b/lib/src/configuration.rs
@@ -40,6 +40,9 @@ impl Configuration {
     }
 
     pub fn set_base_path(&mut self, base_path: &str) -> &mut Self {
+        if base_path.is_empty() || !base_path.starts_with('/') {
+            panic!("Invalid base path");
+        }
         self.base_path = base_path.to_string();
         self
     }

--- a/lib/src/configuration.rs
+++ b/lib/src/configuration.rs
@@ -1,0 +1,59 @@
+#[derive(Debug, Clone)]
+pub struct Configuration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+}
+
+// Check whether defining BasicAuth works like this or not, else revert to the basic definition commented out
+#[derive(Debug, Clone)]
+pub struct BasicAuth {
+    pub username: String,
+    pub password: Option<String>,
+}
+// pub type BasicAuth = (String, Option<String>);
+
+#[derive(Debug, Clone)]
+pub struct ApiKey {
+    pub prefix: Option<String>,
+    pub key: String,
+}
+
+impl Configuration {
+    pub fn new(
+        base_path: String,
+        user_agent: Option<String>,
+        basic_auth: Option<BasicAuth>,
+        oauth_access_token: Option<String>,
+    ) -> Self {
+        Configuration {
+            base_path,
+            user_agent,
+            basic_auth,
+            oauth_access_token,
+            bearer_access_token: None,
+            api_key: None,
+        }
+    }
+
+    pub fn set_base_path(&mut self, base_path: &str) -> &mut Self {
+        self.base_path = base_path.to_string();
+        self
+    }
+}
+
+impl Default for Configuration {
+    fn default() -> Self {
+        Configuration {
+            base_path: "localhost".to_owned(),
+            user_agent: Some("GA4GH SDK".to_owned()),
+            basic_auth: None,
+            oauth_access_token: None,
+            bearer_access_token: None,
+            api_key: None,
+        }
+    }
+}

--- a/lib/src/transport.rs
+++ b/lib/src/transport.rs
@@ -1,0 +1,130 @@
+use crate::configuration::Configuration;
+use log::error;
+use reqwest::Client;
+use serde_json::Value;
+use std::error::Error;
+
+// note: could implement custom certs handling, such as in-TEE generated ephemerial certs
+#[derive(Clone, Debug)]
+pub struct Transport {
+    pub config: Configuration,
+    pub client: reqwest::Client,
+}
+
+impl Transport {
+    pub fn new(config: &Configuration) -> Self {
+        Transport {
+            config: config.clone(),
+            client: Client::new(),
+        }
+    }
+
+    async fn request(
+        &self,
+        method: reqwest::Method,
+        endpoint: &str,
+        data: Option<Value>,
+        params: Option<Value>,
+    ) -> Result<String, Box<dyn Error>> {
+        let full_url = format!("{}{}", self.config.base_path, endpoint);
+        let url = reqwest::Url::parse(&full_url).map_err(|_| {
+            error!("Invalid endpoint (shouldn't contain base url): {}", endpoint);
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid endpoint")) as Box<dyn std::error::Error>
+        })?;
+
+        let mut request_builder = self.client.request(method, url).header(
+            reqwest::header::USER_AGENT,
+            self.config.user_agent.clone().unwrap_or_default(),
+        );
+
+        if let Some(ref params_value) = params {
+            // Validate or log params_value before setting it as query parameters
+            if params_value.is_object() {
+                request_builder = request_builder.query(params_value);
+            } else {
+                error!("params_value is not an object and cannot be used as query parameters: {:?}", params_value);
+                return Err(Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, "params_value must be an object")));
+            }
+        }
+
+        if let Some(ref data) = data {
+            request_builder = request_builder.json(&data);
+        }
+
+        let resp = request_builder.send().await.map_err(|e| {
+	            eprintln!("HTTP request failed: {}", e);
+	            e
+	        })?;
+
+        let status = resp.status();
+        let content = resp.text().await.map_err(|e| format!("Failed to read response text: {}", e))?;
+
+        if status.is_success() {
+            Ok(content)
+        } else {
+            Err(Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Request failed with status: {}. Response: {}", status, content),
+            )))
+        }
+    }
+
+    pub async fn get(
+        &self,
+        endpoint: &str,
+        params: Option<Value>,
+    ) -> Result<String, Box<dyn Error>> {
+        self.request(reqwest::Method::GET, endpoint, None, params)
+            .await
+    }
+
+    pub async fn post(
+        &self,
+        endpoint: &str,
+        data: Option<Value>,
+    ) -> Result<String, Box<dyn Error>> {
+        self.request(reqwest::Method::POST, endpoint, data, None)
+            .await
+    }
+
+    pub async fn put(&self, endpoint: &str, data: Value) -> Result<String, Box<dyn Error>> {
+        self.request(reqwest::Method::PUT, endpoint, Some(data), None)
+            .await
+    }
+
+    pub async fn delete(&self, endpoint: &str) -> Result<String, Box<dyn Error>> {
+        self.request(reqwest::Method::DELETE, endpoint, None, None)
+            .await
+    }
+
+    // other HTTP methods can be added here
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::configuration::Configuration;
+    use crate::test_utils::setup;
+    use crate::transport::Transport;
+    use mockito::mock;
+
+    #[tokio::test]
+    async fn test_request() {
+        setup();
+        let base_url = &mockito::server_url();
+        // effectively no sense in testing various responses, as it's reqwest's responsibility
+        // we should test Transport's methods
+        let _m = mock("GET", "/test")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"message": "success"}"#)
+            .create();
+
+        let config = Configuration::new(base_url.clone(),None, None, None);
+        let transport = Transport::new(&config.clone());
+        let response = transport.get("/test", None).await;
+
+        assert!(response.is_ok());
+        let body = response.unwrap();
+        assert_eq!(body, r#"{"message": "success"}"#);
+    }
+}

--- a/lib/src/transport.rs
+++ b/lib/src/transport.rs
@@ -38,10 +38,10 @@ impl Transport {
             request_builder = request_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
         }
         
-        let mut request_builder = self.client.request(method, url).header(
-            reqwest::header::USER_AGENT,
-            self.config.user_agent.clone().unwrap_or_default(),
-        );
+        // let mut request_builder = self.client.request(method, url).header(
+        //     reqwest::header::USER_AGENT,
+        //     self.config.user_agent.clone().unwrap_or_default(),
+        // );
 
         if let Some(ref params_value) = params {
             // Validate or log params_value before setting it as query parameters

--- a/lib/src/transport.rs
+++ b/lib/src/transport.rs
@@ -37,11 +37,6 @@ impl Transport {
         if let Some(ref user_agent) = self.config.user_agent {
             request_builder = request_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
         }
-        
-        // let mut request_builder = self.client.request(method, url).header(
-        //     reqwest::header::USER_AGENT,
-        //     self.config.user_agent.clone().unwrap_or_default(),
-        // );
 
         if let Some(ref params_value) = params {
             // Validate or log params_value before setting it as query parameters

--- a/lib/src/transport.rs
+++ b/lib/src/transport.rs
@@ -28,7 +28,7 @@ impl Transport {
     ) -> Result<String, Box<dyn Error>> {
         let full_url = format!("{}{}", self.config.base_path, endpoint);
         let url = reqwest::Url::parse(&full_url).map_err(|_| {
-            error!("Invalid endpoint (shouldn't contain base url): {}", endpoint);
+            error!("Invalid endpoint (shouldn't contain base url): {}. Error: {}", endpoint, e);
             Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid endpoint")) as Box<dyn std::error::Error>
         })?;
 
@@ -48,7 +48,12 @@ impl Transport {
         }
 
         if let Some(ref data) = data {
-            request_builder = request_builder.json(&data);
+            if serde_json::to_string(&data).is_ok() {
+                request_builder = request_builder.json(&data);
+            } else {
+                eprintln!("Parameters are invalid, and can't convert to JSON. Error: {}", e);
+	            e
+            }
         }
 
         let resp = request_builder.send().await.map_err(|e| {
@@ -57,7 +62,9 @@ impl Transport {
 	        })?;
 
         let status = resp.status();
-        let content = resp.text().await.map_err(|e| format!("Failed to read response text: {}", e))?;
+        let content = resp.text().await.map_err(|e| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, format!("Failed to read response text: {}", e))
+        })?;
 
         if status.is_success() {
             Ok(content)


### PR DESCRIPTION
Here,

- **Config Struct**: Is responsible for defining a struct, which stores the key details of the request being made to the API
- **Transport Struct**: Is basically config class with a Client, which is used to create a template, which can make GET, POST, PUT and DELETE methods from the reqwest

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces two new structs: `Configuration` for storing API request details and `Transport` for making HTTP requests using the `reqwest` library. It also includes unit tests for the `Transport` struct.

- **New Features**:
    - Introduced a `Configuration` struct to store key details of API requests, including base path, user agent, authentication, and API key information.
    - Added a `Transport` struct that utilizes the `Configuration` struct and a `reqwest::Client` to facilitate making GET, POST, PUT, and DELETE HTTP requests.
- **Tests**:
    - Added unit tests for the `Transport` struct to verify the functionality of HTTP methods using the `mockito` library.

<!-- Generated by sourcery-ai[bot]: end summary -->