### PR TITLE
feat: adding service info

### DIFF
--- a/lib/src/serviceinfo/mod.rs
+++ b/lib/src/serviceinfo/mod.rs
@@ -1,0 +1,62 @@
+pub mod models;
+use crate::configuration::Configuration;
+use crate::transport::Transport;
+
+#[derive(Clone)]
+pub struct ServiceInfo {
+    transport: Transport,
+}
+
+impl ServiceInfo {
+    pub fn new(config: &Configuration) -> Result<Self, Box<dyn std::error::Error>> {
+        let transport = &Transport::new(config);
+        let instance = ServiceInfo {
+            transport: transport.clone(),
+        };
+        Ok(instance)
+    }
+
+    pub async fn get(&self) -> Result<models::Service, Box<dyn std::error::Error>> {
+        let response = self.transport.get("/service-info", None).await;
+        match response {
+            Ok(response_body) => match serde_json::from_str::<models::Service>(&response_body) {
+                Ok(service) => Ok(service),
+                Err(e) => {
+                    log::error!("Failed to deserialize response: {}", e);
+                    Err(e.into())
+                }
+            },
+            Err(e) => {
+                log::error!("Error: {}", e);
+                Err(e)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::configuration::Configuration;
+    use crate::serviceinfo::ServiceInfo;
+    use crate::test_utils::{ensure_funnel_running, setup};
+    use tokio;
+
+    #[tokio::test]
+    async fn test_get_service_info_from_funnel() {
+        setup();
+        let mut config = Configuration::default();
+        let funnel_url = ensure_funnel_running().await;
+        config.set_base_path(&funnel_url);
+        let service_info = ServiceInfo::new(&config).unwrap();
+
+        // Call get_service_info and print the result
+        match service_info.get().await {
+            Ok(service) => {
+                println!("Service Info: {:?}", service);
+            }
+            Err(e) => {
+                println!("Failed to get service info: {}", e);
+            }
+        }
+    }
+}

--- a/lib/src/serviceinfo/mod.rs
+++ b/lib/src/serviceinfo/mod.rs
@@ -9,7 +9,7 @@ pub struct ServiceInfo {
 
 impl ServiceInfo {
     pub fn new(config: &Configuration) -> Result<Self, Box<dyn std::error::Error>> {
-        let transport = &Transport::new(config);
+        let transport = Transport::new(config);
         let instance = ServiceInfo {
             transport: transport.clone(),
         };
@@ -27,7 +27,7 @@ impl ServiceInfo {
                 }
             },
             Err(e) => {
-                log::error!("Error: {}", e);
+                log::error!("Failed to deserialize response: {}. Response body: {}", e, response_body);
                 Err(e)
             }
         }
@@ -55,7 +55,7 @@ mod tests {
                 println!("Service Info: {:?}", service);
             }
             Err(e) => {
-                println!("Failed to get service info: {}", e);
+                log::error!("ServiceInfo error in module 'mod.rs': {}", e);
             }
         }
     }

--- a/lib/src/serviceinfo/mod.rs
+++ b/lib/src/serviceinfo/mod.rs
@@ -22,12 +22,12 @@ impl ServiceInfo {
             Ok(response_body) => match serde_json::from_str::<models::Service>(&response_body) {
                 Ok(service) => Ok(service),
                 Err(e) => {
-                    log::error!("Failed to deserialize response: {}", e);
+                    log::error!("Failed to deserialize response: {}. Response body: {}", e, response_body);
                     Err(e.into())
                 }
             },
             Err(e) => {
-                log::error!("Failed to deserialize response: {}. Response body: {}", e, response_body);
+                log::error!("Error getting response: {}", e);
                 Err(e)
             }
         }


### PR DESCRIPTION
This is the service info class, which can take in the details of any implementation of the main GA4GH API's and return its details. For unit testing, currently Funnel is used

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a new ServiceInfo class to manage and retrieve details of GA4GH API implementations. It also includes a unit test to ensure the correct functionality of the ServiceInfo class using Funnel.

- **New Features**:
    - Introduced the ServiceInfo class to handle details of any implementation of the main GA4GH API and return its details.
- **Tests**:
    - Added a unit test to verify the functionality of the ServiceInfo class using Funnel.

<!-- Generated by sourcery-ai[bot]: end summary -->