### PR TITLE
fix: fix up some module paths

### DIFF
--- a/lib/src/clients/tes/mod.rs
+++ b/lib/src/clients/tes/mod.rs
@@ -76,7 +76,7 @@
 /// ```rust
 /// use ga4gh_sdk::clients::tes::TES;
 /// use ga4gh_sdk::utils::configuration::Configuration;
-/// use ga4gh_sdk::clients::tes::model::ListTasksParams;
+/// use ga4gh_sdk::clients::tes::models::ListTasksParams;
 ///
 /// # async fn test_tes_list_tasks() -> Result<(), Box<dyn std::error::Error>> {
 /// let config = Configuration::new(url::Url::parse("http://example.com")?);

--- a/lib/tests/funnel_tes.rs
+++ b/lib/tests/funnel_tes.rs
@@ -3,7 +3,7 @@
 mod tests {
     use ga4gh_sdk::utils::configuration::Configuration;
     use ga4gh_sdk::clients::tes::models::TesTask;
-    use ga4gh_sdk::clients::tes::model::ListTasksParams;
+    use ga4gh_sdk::clients::tes::models::ListTasksParams;
     use ga4gh_sdk::clients::tes::Task;
     use ga4gh_sdk::clients::tes::models::TesState;
     use ga4gh_sdk::clients::tes::TES;


### PR DESCRIPTION
To get the tests to run (doctests and integration tests) I had to update two module imports.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix module import paths in the TES client to resolve issues with running doctests and integration tests.

Bug Fixes:
- Correct module import paths from 'model' to 'models' in the TES client to ensure tests run successfully.

<!-- Generated by sourcery-ai[bot]: end summary -->