### PR TITLE
fix: set mac linking args

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -24,6 +24,9 @@ serde_json = "1.0.132"
 tokio = "1.41.0"
 url = "2.5.2"
 
+[build-dependencies]
+pyo3-build-config = "0.22.5"
+
 [package.metadata.maturin]
 name = "GA4GH"
 bindings = "pyo3"

--- a/python/build.rs
+++ b/python/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+  pyo3_build_config::add_extension_module_link_args();
+}


### PR DESCRIPTION
On macOS, certain linking arguments need to be provided for the Python library to be built (see https://pyo3.rs/v0.22.5/building-and-distribution#macos). This PR adds those arguments via the first option in the docs linked before.

I'm not a Rust expert, so it may be that things are supposed to work on macOS without additional fixes, and that the linking errors that I see are regressions.

## Summary by Sourcery

Bug Fixes:
- Fix linking issues on macOS by adding necessary build dependencies and linking arguments for the Python library.