### PR TITLE
Fix unused variable

### DIFF
--- a/lib/src/clients/tes/models/tes_task.rs
+++ b/lib/src/clients/tes/models/tes_task.rs
@@ -63,7 +63,7 @@ impl TesTask {
             inputs: None,
             outputs: None,
             resources: None,
-            executors: None,
+            executors: Some(executors),
             volumes: None,
             tags: None,
             logs: None,


### PR DESCRIPTION
warning: unused variable: `executors`
  --> lib/src/clients/tes/models/tes_task.rs:57:16
   |
57 |     pub fn new(executors: Vec<models::TesExecutor>) -> TesTask {
   |                ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_executors`
   |
   = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

## Summary by Sourcery

Bug Fixes:
- Assign the provided executors vector to the TesTask struct instead of leaving it unused